### PR TITLE
fix(botcopy-custom-payloads.md): fix last table format, add gitignore for os files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# OS and System Files
+# macOS - System files that store metadata, icons, and settings
+.DS_Store
+.DS_Store?
+._*
+.AppleDouble
+.LSOverride
+Icon
+.Spotlight-V100
+.Trashes
+
+# Windows - System-generated files and folders
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+[Dd]esktop.ini
+$RECYCLE.BIN/
+*.lnk
+
+# Linux - System and folder-specific files
+.directory
+.Trash-*
+
+# Editor directories/files - IDE settings and cache files
+.cursor/
+.idea/
+.vscode/*
+!.vscode/extensions.json
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+*.sublime-workspace

--- a/docs/responses/botcopy-custom-payloads.md
+++ b/docs/responses/botcopy-custom-payloads.md
@@ -743,10 +743,10 @@ An array of buttons, each with its own action. Buttons are exclusively used with
 ```
 
 #### Properties
-| **Name**     | **Type**    | **Description**                                                                                  |
-| `title`      | `string`    | The text displayed on the button.                                                               |
-| `action`     | `object`    | Defines the behavior of the button. Must be a single action, such as:                           |
-|              |             | - **[message](#message)**:                              |
-|              |             | - **[link](#link)**:                                        |
 
-
+| **Name** | **Type** | **Description**                                                       |
+|----------|----------|-----------------------------------------------------------------------|
+| `title`  | `string` | The text displayed on the button.                                     |
+| `action` | `object` | Defines the behavior of the button. Must be a single action, such as: |
+|          |          | - **[message](#message)**                                             |
+|          |          | - **[link](#link)**                                                   |


### PR DESCRIPTION
This format-only commit fixes the broken table on the official Botcopy docs website:

<img width="1073" alt="Screenshot 2025-06-10 at 12 40 44 PM" src="https://github.com/user-attachments/assets/8f63e305-b82e-4b45-8fb4-5c268ff70317" />

Closes #63 