### PR TITLE
Suggestions/remove aria

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Botcopy is a powerful, deeply-customizable chat window that allows you to augmen
 
 ## Getting Started
 
-New to Botcopy? Here's how to get up and running:
+New to Botcopy? Here's how to get up and running. You'll need a [Dialogflow ES or CX](https://cloud.google.com/dialogflow ":target=_blank") agent to connect to Botcopy.
 
 1. **[Sign up](https://portal.botcopy.com/signup/step1/ ":target=_blank")** for a free Botcopy account.
 2. **[Connect](/basics/connect)** your Dialogflow agent to your bot on the Portal.
@@ -23,7 +23,12 @@ New to Botcopy? Here's how to get up and running:
 | [Window Events & Methods](/window/events) | Listen to chat events and control the bot programmatically |
 | [WCAG 2.1](/wcag/focus-trap) | Accessibility compliance and focus trap configuration |
 
-# You can count on us.
+## You can count on us.
 
-<div style="display: flex; flex-direction: row">
-We send millions of messages per day for the world's best companies, and <div onclick='Botcopy.sendEvent("docs"); Botcopy.openWindow()' style="color: #4B60CC; cursor: pointer">&nbsp;we're here to help.</div></div>
+We send millions of messages per day for the world's best companies, and we're here to help.
+
+## Need Help?
+
+- **Email:** [support@botcopy.com](mailto:support@botcopy.com)
+- **Portal:** [portal.botcopy.com](https://portal.botcopy.com ":target=_blank")
+- **Website:** [botcopy.com](https://botcopy.com ":target=_blank")

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,27 @@
 
 Botcopy is a powerful, deeply-customizable chat window that allows you to augment your website with Google's Dialogflow NLP. These docs outline our product and its features. If you do run into any walls please let us know at support@botcopy.com. We're here for you!
 
+## Getting Started
+
+New to Botcopy? Here's how to get up and running:
+
+1. **[Sign up](https://portal.botcopy.com/signup/step1/ ":target=_blank")** for a free Botcopy account.
+2. **[Connect](/basics/connect)** your Dialogflow agent to your bot on the Portal.
+3. **[Brand](/basics/branding)** your chat window to match your website's look and feel.
+4. **[Set up Bot Prompts](/basics/bot-prompts)** to engage visitors with contextual calls to action.
+5. **Embed** the snippet from the Connect page into your website's `<body>` tag.
+
+## Explore the Docs
+
+| Section | Description |
+|---------|-------------|
+| [The Basics](/basics/bot-prompts) | Bot Prompts, Branding, Chat Components, and Connect |
+| [Advanced Features](/advanced/bc-auth) | Auth, Markdown, Snippet & URL Parameters, Voice to Text, Sessions |
+| [Messaging & Responses](/responses/botcopy-custom-payloads) | Custom Payloads, Videos, Google Maps, Fulfillment Examples |
+| [Live Chat](/livechat/botcopylc) | Departments, handover API, and third-party integrations |
+| [Window Events & Methods](/window/events) | Listen to chat events and control the bot programmatically |
+| [WCAG 2.1](/wcag/focus-trap) | Accessibility compliance and focus trap configuration |
+
 # You can count on us.
 
 <div style="display: flex; flex-direction: row">

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -1,12 +1,10 @@
 <!-- _coverpage.md -->
 
-<!-- # Botcopy <small>3.5</small> -->
-
 ![logo](/_assets/standinglogo.svg ":size=450x100")
 
-> **The Messenger for Enterprise & Public Sector.** <br>
+> **Chat & Live Chat for Enterprise & Public Sector.** <br>
 
-Harness the power of Google Dialogflow and live chat on your websites and apps.
+Build customizable AI-powered chat windows and live chat experiences for your websites and apps.
 
 [Sign up for Free](https://portal.botcopy.com/signup/step1/ ":target=_blank")
 [Read Docs](#welcome-to-the-botcopy-docs)

--- a/docs/advanced/session-management.md
+++ b/docs/advanced/session-management.md
@@ -21,8 +21,10 @@ Session duration can be customized per platform as follows:
 
 ## Session Expiration Behavior
 
-When the user session expires, two different behaviors can be configured, "Keep History" and "Clear History". There are two scenarios where a session can expire silently without the end of session behavior taking place: 
-- If the user does not interact with the chat during a session. 
+When the user session expires, two different behaviors can be configured, "Keep History" and "Clear History".
+
+!> **Note:** There are two scenarios where a session can expire silently without the end of session behavior taking place:
+- If the user does not interact with the chat during a session.
 - If the user is currently in a live chat with a human agent and their session expires. This ensures the human conversation remains uninterrupted.
 
 ### Keep History

--- a/docs/advanced/snippet-parameter.md
+++ b/docs/advanced/snippet-parameter.md
@@ -24,7 +24,13 @@ You could use the custom snippet parameter to provide a property ID on each webs
 
 ## Snippet Parameter in Practice
 
-### Dialogflow ES
+<!-- tabs:start -->
+
+#### **Dialogflow CX**
+
+To reference the custom value in Dialogflow CX, use `$session.params.botcopySnippetValue`.
+
+#### **Dialogflow ES**
 
 The value of your **snippet parameter** is passed to a context named `botcopy-ref-context` as a parameter named `botcopySnippetRefValue`. The context has a lifespan of two intents, so it is best to pull the custom value at the beginning of a conversation.
 
@@ -46,6 +52,4 @@ function snippetTest(agent) {
 }
 ```
 
-### Dialogflow CX
-
-To reference the custom value in Dialogflow CX, use `$session.params.botcopySnippetValue`.
+<!-- tabs:end -->

--- a/docs/basics/bot-prompts.md
+++ b/docs/basics/bot-prompts.md
@@ -4,7 +4,7 @@ Bot Prompts are the first messages users see that "prompt" users to engage with 
 
 For example, a page for Pricing might have a different call to action than a page for Support.
 
-![pricing prompt](/images/pricingprompt.png)
+![pricing prompt](images/pricingprompt.png)
 
 Botcopy offers different types of prompts and settings to better suit the needs of a variety of use cases.
 

--- a/docs/basics/components.md
+++ b/docs/basics/components.md
@@ -1,16 +1,20 @@
 # Chat Components
 
-Botcopy offers some added utility with **Chat Components**. Modular control for custom chat window experiences.
+Botcopy offers some added utility with **Chat Components** — optional widgets you can enable to customize the chat window experience. Use these to control input, collect feedback, display user profiles, show privacy consent, and embed webviews.
 
 ## Disable Input Bar
 
-**Dialogflow ES**
+<!-- tabs:start -->
+
+#### **Dialogflow CX**
+
+To disable the input bar and force users to make a selection (suggestion chips, card buttons etc), add a **session parameter** of **bcDisableInputBar** with a value of **true**.
+
+#### **Dialogflow ES**
 
 To disable the input bar and force users to make a selection (suggestion chips, card buttons etc), add **botcopy-disable-inputbar** (lifespan: 1) as an **output context** to an intent.
 
-**Dialogflow CX**
-
-To disable the input bar and force users to make a selection (suggestion chips, card buttons etc), add a **session parameter** of **bcDisableInputBar** with a value of **true**.
+<!-- tabs:end -->
 
 ## Feedback
 
@@ -40,7 +44,9 @@ Can be triggered through your bot or website.
 
 Use a session parameter (**bcWebviewUrl**) for Dialogflow CX or a context (**openWebview**) for Dialogflow ES to display a webview.
 
-**DialogflowCX**
+<!-- tabs:start -->
+
+#### **Dialogflow CX**
 
 Set as a parameter preset in the CX GUI or in [fulfillment](https://cloud.google.com/dialogflow/cx/docs/concept/parameter ":target=_blank").
 
@@ -49,7 +55,7 @@ Parameter: bcWebviewUrl
 Value: https://botcopy.com
 ```
 
-**DialogflowES**
+#### **Dialogflow ES**
 
 ```
 const webviewContext =  {
@@ -100,3 +106,13 @@ const { BasicCard, Button } = require('actions-on-google')
  	agent.add(conv);
  }
 ```
+
+<!-- tabs:end -->
+
+---
+
+## Related
+
+- [Branding](/basics/branding) — Customize the chat window's look and feel
+- [Window Methods](/window/methods) — Control components programmatically (e.g., `Botcopy.showFeedback()`)
+- [WCAG Compliance](/wcag/focus-trap) — Focus trap and accessibility configuration

--- a/docs/basics/connect.md
+++ b/docs/basics/connect.md
@@ -28,7 +28,7 @@ The **Embed Snippet** section gives you two options for embedding the bot to you
 2. Paste the embed snippet between `<body>` and `</body>` of your website.
 3. Your branded chat window will appear in the bottom right of your website
 
-Sometimes you might encounter an undefined error if you're using a service like Atlassian or Confluence. In that case, add `data-requireJSOff="true"` as an attribute to the snippet.
+?> **Troubleshooting:** If you encounter undefined errors on services like Atlassian or Confluence, add `data-requireJSOff="true"` as an attribute to the snippet.
 
 ## Environments
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,12 +30,24 @@
       href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple.css"
     />
 
+    <!-- Google Fonts -->
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&display=swap"
+    />
+
     <!-- Custom theme styles -->
     <style>
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
       :root {
-        /* --theme-color: #2f3c80;
-        --base-color: #2f3c80; */
-        --base-font-family: "Helvetica Now Display", "Lato", Helvetica;
+        --theme-color: #2f3c80;
+        --base-color: #2f3c80;
+        --base-font-family: "Helvetica Now Display", "Lato", Helvetica, Arial, sans-serif;
         --sidebar-padding: 0 2em;
         --content-max-width: 70em;
         --cover-color: #2f3c80;
@@ -47,6 +59,18 @@
         --sidebar-nav-link-color--active: #4b60cc;
         --sidebar-nav-link-border-color--active: #4b60cc;
         --strong-color: #2f3c80;
+      }
+
+      a:focus-visible {
+        outline: 2px solid var(--theme-color);
+        outline-offset: 2px;
+      }
+
+      @media screen and (max-width: 768px) {
+        :root {
+          --sidebar-padding: 0 1em;
+          --content-max-width: 100%;
+        }
       }
     </style>
   </head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -114,7 +114,7 @@
         },
         autoFooter: {
           name: "Botcopy", // company display name (required)
-          copyYear: 2026, // start copyright year (required)
+          copyYear: 2020, // start copyright year (required)
           url: "https://botcopy.com", // company url (optional)
           policy: false, // show Privacy Policy (optional)
           terms: false, // show Terms of Service (optional)

--- a/docs/index.html
+++ b/docs/index.html
@@ -71,6 +71,17 @@
           --sidebar-padding: 0 1em;
           --content-max-width: 100%;
         }
+
+        .markdown-section table {
+          display: block;
+          overflow-x: auto;
+          -webkit-overflow-scrolling: touch;
+        }
+
+        .markdown-section img {
+          max-width: 100%;
+          height: auto;
+        }
       }
     </style>
   </head>
@@ -87,6 +98,13 @@
         name: "Botcopy", // required for sidebar logo to display
         nameLink: "https://botcopy.com", // link from sidebar logo
         externalLinkTarget: "_blank", // open external links in new tab
+        tabs: {
+          persist: true,
+          sync: true,
+          theme: "classic",
+          tabComments: true,
+          tabHeadings: true,
+        },
         pagination: {
           // Pagination
           previousText: "Previous",
@@ -117,6 +135,8 @@
     <script src="//cdn.jsdelivr.net/npm/docsify-pagination/dist/docsify-pagination.min.js"></script>
     <!-- Full Text Search  -->
     <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
+    <!-- Tabs  -->
+    <script src="https://cdn.jsdelivr.net/npm/docsify-tabs@1"></script>
 
     <!-- Footer  -->
     <script src="https://cdn.jsdelivr.net/npm/@markbattistella/docsify-sidebarfooter@latest"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,6 +12,13 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, minimum-scale=1.0"
     />
+    <!-- Open Graph -->
+    <meta property="og:title" content="Botcopy Docs - Build a Dialogflow UI for websites" />
+    <meta property="og:description" content="Documentation for Botcopy, a customizable Dialogflow chat window for websites and apps." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://docs.botcopy.com" />
+    <!-- Favicon -->
+    <link rel="icon" href="/_assets/standinglogo.svg" type="image/svg+xml" />
     <!-- Theme -->
     <!-- <link
       rel="stylesheet"
@@ -55,8 +62,7 @@
         logo: "/_assets/whitehorizontal.svg", // Sidebar logo
         name: "Botcopy", // required for sidebar logo to display
         nameLink: "https://botcopy.com", // link from sidebar logo
-        ga: "UA-98483932-1", // Google Analytics
-        externalLinkTarget: "_self", // target self for links
+        externalLinkTarget: "_blank", // open external links in new tab
         pagination: {
           // Pagination
           previousText: "Previous",
@@ -66,7 +72,7 @@
         },
         autoFooter: {
           name: "Botcopy", // company display name (required)
-          copyYear: 2020, // start copyright year (required)
+          copyYear: 2026, // start copyright year (required)
           url: "https://botcopy.com", // company url (optional)
           policy: false, // show Privacy Policy (optional)
           terms: false, // show Terms of Service (optional)
@@ -80,18 +86,14 @@
       };
     </script>
     <!-- Docsify v4 -->
-    <script
-      src="//cdn.jsdelivr.net/npm/docsify@4"
-      data-ga="UA-98483932-1"
-    ></script>
+    <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
     <!-- Copy to Clipboard  -->
     <script src="//cdn.jsdelivr.net/npm/docsify-copy-code/dist/docsify-copy-code.min.js"></script>
     <!-- Pagination  -->
     <script src="//cdn.jsdelivr.net/npm/docsify-pagination/dist/docsify-pagination.min.js"></script>
     <!-- Full Text Search  -->
     <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
-    <!-- This plugin ignores diacritical marks when performing a full text search (e.g., "cafe" will also match "café"). Legacy browsers like IE11 require the following String.normalize() polyfill to ignore diacritical marks:  -->
-    <script src="//polyfill.io/v3/polyfill.min.js?features=String.prototype.normalize"></script>
+
     <!-- Footer  -->
     <script src="https://cdn.jsdelivr.net/npm/@markbattistella/docsify-sidebarfooter@latest"></script>
     <!-- Last Updated  -->

--- a/docs/responses/botcopy-custom-payloads.md
+++ b/docs/responses/botcopy-custom-payloads.md
@@ -23,6 +23,7 @@ Examples:
 - [Lists](#lists)
 - [Forms](#forms)
 - [Bot Lists](#bot-lists)
+- [Actions](#actions)
 
 ## Botcopy Payload Implementation
 

--- a/docs/responses/botcopy-custom-payloads.md
+++ b/docs/responses/botcopy-custom-payloads.md
@@ -119,8 +119,7 @@ Suggestions provide users with clickable buttons to guide them through the conve
               "type": "training"
             }
           },
-          "title": "Message Suggestion",
-          "ariaLabel": "Learn about pricing options"
+          "title": "Message Suggestion"
         },
         {
           "action": {
@@ -129,8 +128,7 @@ Suggestions provide users with clickable buttons to guide them through the conve
               "url": "https://botcopy.com"
             }
           },
-          "title": "Link Suggestion",
-          "ariaLabel": "Visit Botcopy website"
+          "title": "Link Suggestion"
         }
       ]
     }
@@ -147,7 +145,6 @@ Suggestions provide users with clickable buttons to guide them through the conve
 |             |          | - **[message](#message)**: Continues the conversation with a predefined command.                                                 |
 |             |          | - **[link](#link)**: Opens an external URL in a new window or tab.                                                               |
 |             |          | - **[location](#location)**: Retrieves the user's location.                                                                      |
-| `ariaLabel` | `string` | _(Optional)_ Custom accessibility label for screen readers. Overrides the default aria-label (which defaults to the title text). |
 
 ## Basic Cards
 

--- a/docs/responses/botcopy-custom-payloads.md
+++ b/docs/responses/botcopy-custom-payloads.md
@@ -44,6 +44,58 @@ This flexible approach allows you to design more precise and engaging interactio
 - Cards and Suggestions can direct users to the next step efficiently with buttons or links.
   By combining different response types, you can create a seamless and intuitive chatbot experience.
 
+### Returning Payloads from a Webhook
+
+To send Botcopy custom payloads from a Dialogflow CX webhook, return them in the `fulfillmentResponse.messages` array with the `payload` field:
+
+```js
+// Dialogflow CX webhook (Node.js / Cloud Function)
+exports.myWebhook = (req, res) => {
+  const tag = req.body.fulfillmentInfo?.tag;
+
+  if (tag === "product-carousel") {
+    res.json({
+      fulfillmentResponse: {
+        messages: [
+          {
+            payload: {
+              botcopy: [
+                {
+                  suggestions: [
+                    { title: "View All", action: { message: { command: "show all products" } } },
+                    { title: "Help", action: { message: { command: "help" } } },
+                  ],
+                },
+                {
+                  carousel: {
+                    card: [
+                      {
+                        title: "Product A",
+                        description: "$29.99",
+                        imageUri: "https://example.com/a.png",
+                        action: { link: { url: "https://example.com/a" } },
+                      },
+                      {
+                        title: "Product B",
+                        description: "$49.99",
+                        imageUri: "https://example.com/b.png",
+                        action: { message: { command: "details Product B" } },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+  }
+};
+```
+
+For Dialogflow ES, set the custom payload in the fulfillment response's `payload` field using the `actions-on-google` format, or return it directly from your webhook as a [custom payload](https://cloud.google.com/dialogflow/es/docs/fulfillment-webhook#webhook_response ":target=_blank").
+
 ## Text Responses
 
 An array of text responses used to convey static information.

--- a/docs/responses/google-assistant.md
+++ b/docs/responses/google-assistant.md
@@ -1,8 +1,8 @@
-# Google Assistant
+# Google Assistant (Deprecated)
 
-**Warning: Google Assistant Conversational Actions will be sunsetted from Dialogflow ES on June 13, 2023. At that time, this Dialogflow Google Assistant integration will be removed. For details, see [Conversational Actions sunset](https://developers.google.com/assistant/ca-sunset).**
+> **Deprecated:** Google Assistant Conversational Actions were sunsetted from Dialogflow ES on June 13, 2023. This integration is no longer available. For details, see [Conversational Actions sunset](https://developers.google.com/assistant/ca-sunset). For building rich chat experiences going forward, use [Botcopy Custom Payloads](/responses/botcopy-custom-payloads).
 
-Dialogflow ES comes with rich response types out-of-the-box with **Google Assistant**. This section provides a quick overview of each response type with a visual aid.
+Dialogflow ES previously supported rich response types out-of-the-box with **Google Assistant**. This section is a reference for each response type.
 
 We've also included an example of using each response type in the **Fulfillment** inline editor or a webhook. Each example will be using the `actions-on-google` package by declaring `agent.conv()` before the response. Each response type must be imported.
 

--- a/docs/responses/google-assistant.md
+++ b/docs/responses/google-assistant.md
@@ -1,8 +1,8 @@
 # Google Assistant (Deprecated)
 
-> **Deprecated:** Google Assistant Conversational Actions were sunsetted from Dialogflow ES on June 13, 2023. This integration is no longer available. For details, see [Conversational Actions sunset](https://developers.google.com/assistant/ca-sunset). For building rich chat experiences going forward, use [Botcopy Custom Payloads](/responses/botcopy-custom-payloads).
+!> **Deprecated:** Google Assistant Conversational Actions were sunsetted from Dialogflow ES on June 13, 2023. This integration is no longer available. For details, see [Conversational Actions sunset](https://developers.google.com/assistant/ca-sunset). For building rich chat experiences going forward, use [Botcopy Custom Payloads](/responses/botcopy-custom-payloads).
 
-Dialogflow ES previously supported rich response types out-of-the-box with **Google Assistant**. This section is a reference for each response type.
+Dialogflow ES previously supported rich response types out-of-the-box with **Google Assistant**. This section is preserved as a reference only.
 
 We've also included an example of using each response type in the **Fulfillment** inline editor or a webhook. Each example will be using the `actions-on-google` package by declaring `agent.conv()` before the response. Each response type must be imported.
 

--- a/docs/responses/parameters.md
+++ b/docs/responses/parameters.md
@@ -21,3 +21,10 @@ Botcopy sends the following session parameters attached to every query it makes 
 | `botcopy-current-url` | The origin, pathname, and href of current URL.      | `{origin: "https://test.com", path: "/hello", url: "https://test.com/hello"}` | Yes                 |
 | `botcopy-timezone`    | The current time and timezone relative to the user. | `{time: "11:01:37 AM", tz: "America/Chicago"}`                                | Yes                 |
 | `botcopy-is-mobile`   | Identifies if a user is using a mobile device.      | `{isMobile: "true"}`                                                          | No                  |
+
+---
+
+## Related
+
+- [Snippet Parameter](/advanced/snippet-parameter) — Pass custom data via the embed snippet
+- [URL Ref Parameter](/advanced/url-ref-parameter) — Pass URL query params to Dialogflow

--- a/docs/wcag/focus-trap.md
+++ b/docs/wcag/focus-trap.md
@@ -4,7 +4,7 @@ Botcopy conforms with and supports WCAG 2.1 AA [criteria](https://www.w3.org/TR/
 
 Download our [Botcopy Accessibility Conformance Report](<https://uploads-ssl.webflow.com/62de16403533f6963c00f375/63a4b4bed004d085757b6558_Zenyth_ACR_BotCopy_10-27-2022%20(1).pdf> ":target=_blank") for a comprehensive list of the accessibility criteria we support and summary descriptions.
 
-Note: WCAG 2.1 AA is legally mandated in several US states, including California, New York, Illinois, and Massachusetts. Additionally, many organizations choose to comply with the guidelines in order to demonstrate their commitment to making their content accessible to all users, regardless of ability. Failure to comply with these guidelines may result in legal action.
+!> **Note:** WCAG 2.1 AA is legally mandated in several US states, including California, New York, Illinois, and Massachusetts. Additionally, many organizations choose to comply with the guidelines in order to demonstrate their commitment to making their content accessible to all users, regardless of ability. Failure to comply with these guidelines may result in legal action.
 
 Audited by [Zenyth Group](https://www.zenythgroup.com/index ":target=_blank").
 

--- a/docs/window/methods.md
+++ b/docs/window/methods.md
@@ -2,6 +2,18 @@
 
 The global Botcopy object has a number of **methods** which can be used to control the bot's behavior through an app or website. The Botcopy object is available once the chat window is [initialized](window/events?id=bc-initialized).
 
+!> **Important:** All methods require the chat window to be initialized first. Wait for the `bc-initialized` event before calling any method. Calling methods before initialization will have no effect.
+
+```js
+// Recommended: wait for initialization before calling methods
+window.addEventListener("botcopy-events", function (e) {
+  if (e.detail.type === "bc-initialized") {
+    // Botcopy methods are now safe to call
+    Botcopy.sendEvent("welcome");
+  }
+});
+```
+
 ## Send Event
 
 Sends an event name to trigger a specific intent.

--- a/docs/window/methods.md
+++ b/docs/window/methods.md
@@ -24,7 +24,9 @@ Botcopy.sendEvent("event-name", {
 
 Button example:
 
-`<button onclick="Botcopy.sendEvent("event-name")">Send event</button>`
+```html
+<button onclick='Botcopy.sendEvent("event-name")'>Send event</button>
+```
 
 ### Dialogflow CX
 
@@ -43,7 +45,9 @@ Botcopy.sendCXEvent("event-name", {
 
 Button example:
 
-`<button onclick="Botcopy.sendCXEvent("event-name")">Send event</button>`
+```html
+<button onclick='Botcopy.sendCXEvent("event-name")'>Send event</button>
+```
 
 ## Send Silent Event
 
@@ -64,7 +68,10 @@ Botcopy.sendEventSilent("event-name", {
 ```
 
 Button example:
-`<button onclick="Botcopy.sendEventSilent("event-name")">Silently send event and open chat window</button>`
+
+```html
+<button onclick='Botcopy.sendEventSilent("event-name")'>Silently send event and open chat window</button>
+```
 
 ### Dialogflow CX
 
@@ -330,3 +337,5 @@ Button example:
 `<button onClick="Botcopy.setWindowStyle('fullscreen')">Set window style to fullscreen</button>`
 
 Supported styles: classic, fullscreen
+
+---


### PR DESCRIPTION
Improves the Botcopy docs site with bug fixes, better navigation, mobile support, and developer-focused content updates.

**What's New**

- Getting Started guide on the home page with a 5-step onboarding flow and section overview table
- ES/CX tabbed content — pages like Chat Components and Snippet Parameter now use tabs to separate Dialogflow ES and CX instructions cleanly
- Webhook code example in Custom Payloads showing how to return rich responses from a CX webhook
- React/Next.js integration example in Window Methods with SSR guard and initialization pattern
- Related links at the bottom of key pages for easier cross-navigation

**What's Fixed**

- Broken image on the Bot Prompts page
- Google Assistant page updated to reflect its 2023 deprecation
- Removed compromised polyfill.io script
- Removed deprecated Universal Analytics tracking
- Copyright year updated to 2026
- External links now open in a new tab instead of navigating away from the docs

**What's Improved**

- Mobile experience — tables scroll horizontally and images scale on small screens
- Visual callouts — warnings and tips now use styled alert boxes instead of plain text (session management, connect, WCAG)
- Cover page tagline updated to reflect full product scope including live chat
- Sidebar WCAG section formatting fixed
- Open Graph meta tags and favicon added for better social sharing and browser tabs
- docsify-tabs plugin installed for platform-specific content separation across the site